### PR TITLE
Fixed license name in README and documentation comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # libsoxr-rs
 This library is a thin wrapper for [libsoxr](https://sourceforge.net/projects/soxr/) which is a "High quality, one-dimensional sample-rate conversion library".
 
-This wrapper library is licensed the same as libsoxr itself: GPLv2.
+This wrapper library is licensed the same as libsoxr itself: LGPLv2.
 
 The documentation can be found [here](https://lrbalt.github.io/libsoxr-rs/libsoxr/).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! This library is a thin wrapper for [libsoxr](https://sourceforge.net/projects/soxr/) which is
 //! a "High quality, one-dimensional sample-rate conversion library".
 //!
-//! This wrapper library is licensed the same as libsoxr itself: GPLv2.
+//! This wrapper library is licensed the same as libsoxr itself: LGPLv2.
 //!
 //! The documentation can be found [here](https://lrbalt.github.io/libsoxr-rs/libsoxr/).
 //!


### PR DESCRIPTION
Right now, Cargo.toml and the LICENSE.md files both specify the license as LGPLv2. The README.md specified the license to be "the same as libsoxr itself: GPLv2", but libsoxr is licensed LGPLv2, not GPLv2. The documentation comment in lib.rs appears to be a copy of the README.
