### PR TITLE
Re-export Error and Result types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsoxr"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Reinier Balt <lrbalt@gmail.com>"]
 description = "Wrapper for libsoxr (resampling library for sounds)"
 repository = "https://github.com/lrbalt/libsoxr-rs"

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -2,6 +2,7 @@
 use std::borrow::Cow;
 use std::fmt;
 
+/// A Soxr error
 #[derive(Debug)]
 pub enum ErrorType {
     InvalidString,
@@ -21,15 +22,20 @@ impl fmt::Display for ErrorType {
     }
 }
 
+/// A Soxr error returned from a particular function
 #[derive(Debug)]
-pub struct Error(Option<Cow<'static, str>>, ErrorType);
+pub struct Error {
+    pub function: Option<Cow<'static, str>>,
+    pub error_type: ErrorType
+}
 
 impl Error {
     pub fn new(func: Option<Cow<'static, str>>, t: ErrorType) -> Error {
-        Error(func, t)
+        Error { function: func, error_type: t }
     }
+
     pub fn invalid_str(func: &'static str) -> Error {
-        Error(Some(func.into()), ErrorType::InvalidString)
+        Error::new(Some(func.into()), ErrorType::InvalidString)
     }
 }
 
@@ -41,11 +47,12 @@ impl ::std::error::Error for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            Some(ref s) => write!(f, "SOXR error: '{}' from function '{}'", s, self.1),
-            None => write!(f, "SOXR error: '{}'", self.1),
+        match self.function {
+            Some(ref s) => write!(f, "SOXR error: '{}' from function '{}'", s, self.error_type),
+            None => write!(f, "SOXR error: '{}'", self.error_type),
         }
     }
 }
 
+/// Convenience type alias for `std::result::Result<T, crate::Error>`
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,4 +64,5 @@ pub use crate::{
     datatype::Datatype,
     soxr::Soxr,
     spec::{IOSpec, QualitySpec, RuntimeSpec},
+    error_handling::{ Error, Result }
 };


### PR DESCRIPTION
Rust normally prevents you from defining a public function with a signature involving a private type. However, due to a bug, Rust only checks for a type's `pub` modifier rather than ensuring it's exported from the crate (see [here](https://internals.rust-lang.org/t/private-struct-returned-by-public-fn/8448)). This PR properly re-exports the `Error` and `Result` types so that errors can be properly handled by users of `libsoxr-rs`.

Given that the error type will now be public, I switched to using named public fields inside the Error struct and added some doc comments.